### PR TITLE
Add binding to add verilator linting suppression

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1185,6 +1185,17 @@ hooks.register(hooks.type.HIGHLIGHT_SETUP, function()
   vim.api.nvim_set_hl(0, 'RainbowViolet', { fg = '#C678DD' })
   vim.api.nvim_set_hl(0, 'RainbowCyan', { fg = '#56B6C2' })
 end)
+--
+-- Load the Verilator utility module
+local verilator = require 'modules.insert_verilator_lint'
+
+-- Map the keybinding to the function
+vim.api.nvim_set_keymap(
+  'n',
+  '<leader>v',
+  [[:lua require('modules.insert_verilator_lint').insert_verilator_lint(vim.v.count1)<CR>]],
+  { noremap = true, silent = true }
+)
 
 require('ibl').setup { indent = { highlight = highlight } }
 

--- a/lua/modules/insert_verilator_lint.lua
+++ b/lua/modules/insert_verilator_lint.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+-- Function to insert Verilator lint comments
+function M.insert_verilator_lint(count)
+  count = count or 1 -- Default to 1 if no count is provided
+
+  local word = vim.fn.input 'Enter which warning should be suppressed: '
+  if word == '' then
+    return
+  end
+
+  local line_number = vim.fn.line '.'
+  vim.fn.append(line_number - 1, '// verilator lint_off ' .. word)
+  vim.fn.append(line_number - 1 + count + 1, '// verilator lint_on ' .. word)
+end
+
+return M


### PR DESCRIPTION
This adds the binding `<count><leader>v` which encloses the current line and the following `count-1` lines with 
```
// verilator lint_off <warning>
// verilator lint_on <warning>
```
The command prompts for what to use for `<warning>`. However, the input is not checked further currently, so the spelling has to be checked manually. If no count is given, just the current line is enclosed.